### PR TITLE
fix: Simpler and more robust way to find SDK_PATH for gcloud.

### DIFF
--- a/zsh-gcloud.plugin.zsh
+++ b/zsh-gcloud.plugin.zsh
@@ -6,16 +6,8 @@ if ! (( $+commands[gcloud] )); then
     return
 fi
 
-# Identify the location of the Google Cloud SDK installed
-local DEFAULT_SDK_PATHS=("/opt/homebrew/share/google-cloud-sdk" \
-                         "$HOME/.local/share/mise/installs/gcloud/latest" \
-                         "/usr/share/google-cloud-sdk")
-for sp in "${DEFAULT_SDK_PATHS[@]}"; do
-    if [ -d "$sp" ]; then
-        local SDK_PATH="$sp"
-        break
-    fi
-done
+# Identify the location of the Google Cloud SDK installed: dir containing "bin/gcloud"
+local SDK_PATH=$(dirname $(dirname $(which gcloud)))
 
 # If the Google Cloud SDK path was found
 if [[ ! -z "$SDK_PATH" ]]; then


### PR DESCRIPTION
Hi Matthew.

I found your zsh-gcloud zap plugin. Thanks!

[The default Linux installation instructions](https://cloud.google.com/sdk/docs/install#linux) recommends installing the Google Cloud CLI in `$HOME`, which was not one of the hardcoded locations your plugin searched.

I thought it would be more robust to define the location relative to the location of the `gcloud` command, since the plugin already checks that the command exists. Works for me!

What do you think? 